### PR TITLE
Scan for active devices on i2c bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ I2C buses available:
   pins:
    * SDA: I2C0_SDA(GPIO0)
    * SCL: I2C0_SCL(GPIO1)
+  devices:
+   * addr: 0x39 (57)
 
 - name: /dev/i2c-1
   number: 1
@@ -30,6 +32,13 @@ I2C buses available:
   pins:
    * SDA: I2C1_SDA(GPIO2)
    * SCL: I2C1_SCL(GPIO3)
+  devices:
+   * addr: 0x37 (55)
+   * addr: 0x3A (58)
+   * addr: 0x4A (74)
+   * addr: 0x4B (75)
+   * addr: 0x50 (80)
+   * addr: 0x54 (84)
 
 - name: /dev/i2c-2
   number: 2
@@ -37,6 +46,7 @@ I2C buses available:
   pins:
    * SDA: INVALID
    * SCL: INVALID
+  devices: none found
 
 - name: /dev/i2c-3
   number: 3
@@ -44,6 +54,7 @@ I2C buses available:
   pins:
    * SDA: INVALID
    * SCL: INVALID
+  devices: none found
 ```
 
 ### credits

--- a/main.go
+++ b/main.go
@@ -32,7 +32,8 @@ func main() {
 
 		b, err := ref.Open()
 		if err != nil {
-			fmt.Printf("  Failed to open bus: %v", err)
+			fmt.Printf("  Failed to open bus: %v\n", err)
+			continue
 		}
 
 		fmt.Println("  pins:")

--- a/main.go
+++ b/main.go
@@ -42,8 +42,27 @@ func main() {
 			fmt.Printf("   * SCL: %s\n", p.SCL())
 		}
 
+		var devices []uint8
+		for addr := uint8(0x03); addr <= 0x77; addr++ {
+			// Check whether i2c address is alive by sending 1 null byte and trying to read back
+			write := []byte{0x00}
+			read := make([]byte, 1)
+			if err := b.Tx(uint16(addr), write, read); err == nil {
+				devices = append(devices, addr)
+			}
+		}
+
+		if len(devices) > 0 {
+			fmt.Println("  devices:")
+			for _, d := range devices {
+				fmt.Printf("   * addr: 0x%02X (%d)\n", d, d)
+			}
+		} else {
+			fmt.Println("  devices: none found")
+		}
+
 		if err := b.Close(); err != nil {
-			fmt.Printf("  Failed to close bus: %v", err)
+			fmt.Printf("  Failed to close bus: %v\n", err)
 		}
 
 		fmt.Println()


### PR DESCRIPTION
Sometimes it's important to know which devices are currently connected and active on the i2c bus. This patch adds a list of active devices per i2c bus by probing all addresses per bus by writing one null byte and trying to read back. If successful, this indicates there's a device connected at that address.

Feel free to close it in case you don't like that functionality.